### PR TITLE
Fixed an issue where HandConstraintPalmUp is not working properly

### DIFF
--- a/MRTK-NrealHandTracking/Assets/Nreal/Scripts/NrealController.cs
+++ b/MRTK-NrealHandTracking/Assets/Nreal/Scripts/NrealController.cs
@@ -89,6 +89,8 @@ namespace ARFukuoka.MixedReality.Toolkit.Nreal.Input
             {
                 if (nrealHand != null && nrealHand.GetHandState().isTracked)
                 {
+                    IsPositionAvailable = IsRotationAvailable = true;
+
                     HandJointID jointID = ConvertMRTKJointToNrealJoint(joint);
                     // Get the pose of the nreal joint
                     HandState hand= nrealHand.GetHandState();
@@ -102,6 +104,8 @@ namespace ARFukuoka.MixedReality.Toolkit.Nreal.Input
                 }
                 else
                 {
+                    IsPositionAvailable = IsRotationAvailable = false;
+
                     jointPoses[joint] = MixedRealityPose.ZeroIdentity;
                 }
             }


### PR DESCRIPTION
Looking at the MRTK source codes, IMixedRealityController.IsPositionAvailable needs to be true for HandConstraintPalmUp to work. ([Source](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/0e1756851050646398291b4fd9bd9c1e3e50d789/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs#L151))

NrealController class, and LeapMotionArticulatedHand class that was perhaps the basis for its design, don't seem to set a value to IsPositionAvailable.
WindowsMixedRealityArticulatedHand, OculusHand and some controllers seem to set the value.

This PR sets a value to IsPositionAvailable and fixed an issue where HandConstraintPalmUp is not working properly.

Closes #3